### PR TITLE
Bump up to ruby 2.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+rvm:
+  - 2.4
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   SSL_CERT_FILE: c:\projects\kitchen-machine\certs.pem
 
   matrix:
-    - ruby_version: "23"
+    - ruby_version: "24"
 
 clone_folder: c:\projects\kitchen-machine
 clone_depth: 1


### PR DESCRIPTION
Appveyor build recently failed due to chef-dk requiring ruby 2.4. Let's try requiring ruby 2.4 in our CI config.