### PR TITLE
Change cookbook versioning scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 11.0.2000 2019-03-14
+- Change cookbook versioning scheme [#31]
+
 ## 11.0.2 2019-03-13
 - Java 11.0.2 (build 9)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Installs and configures Oracle's
 See [Critical Patch Updates](http://www.oracle.com/technetwork/topics/security/alerts-086861.html)
 for next scheduled JDK release.
 
+**Important Notice**: The patch version of the cookbook is now 1000 times the patch level of the Java version
+it's installing plus an incrementing number controlled by the cookbook author(s). For example, if the cookbook
+version is `11.0.2000`, then that's the first release of the cookbook for Java 11.0.2. If the cookbook version
+is `11.0.2004`, then that's the fifth release of the cookbook for Java 11.0.2. [#31]
+
 ## Requirements
 
 - Chef 12+

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/vrivellino/chef-java_se' if respond_to?(:source_url)
 issues_url 'https://github.com/vrivellino/chef-java_se/issues' if respond_to?(:issues_url)
 chef_version '>= 12.1' if respond_to?(:chef_version)
-version '11.0.2'
+version '11.0.2002'
 
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
Updates the cookbook version so that the patch version of the cookbook is now 1000 times the patch level of the Java version it's installing plus an incrementing number controlled by the cookbook author(s).

For example, if the cookbook version is `11.0.2000`, then that's the first release of the cookbook for Java 11.0.2. If the cookbook version is `11.0.2004`, then that's the fifth release of the cookbook for Java 11.0.2.

[Closes #31]